### PR TITLE
Per project hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ projects:
   home:
     name: 'Home directory'
     path: '~/'
+    before_switch: 'clear' # (optional) Same as before_switch in config, but configurable per project. Runs after global before_switch.
+    after_switch: 'pwd' # (optional) Same as after_switch in config, but configurable per project. Runs after global after_switch.
 ```
 
 ## Uninstall

--- a/config/.projects.yml.dist
+++ b/config/.projects.yml.dist
@@ -7,7 +7,13 @@
 config:
   alias: 'p' # This is the alias used for the switcher.
 
+  # Optionally you can choose to add hooks, which are commands run before or after switching.
+  before_switch: 'clear' # (optional) hooks with commands to be ran.
+  # after_switch: 'pwd' # (optional) hooks with commands to be ran.
+
 projects:
   home:
     name: 'Home directory'
     path: '~/'
+    # before_switch: 'clear' # (optional) Same as before_switch in config, but configurable per project. Runs after global before_switch.
+    # after_switch: 'pwd' # (optional) Same as after_switch in config, but configurable per project. Runs after global after_switch.

--- a/src/project_switcher.rb
+++ b/src/project_switcher.rb
@@ -98,13 +98,12 @@ class ProjectSwitcher
   def switch_to!(project_key)
     # Check if the project is defined
     if projects.keys.include? project_key
-      run_hook :before
+      run_hook :before, (project = projects[project_key])
 
-      project = projects[project_key]
       exec "cd #{ File.expand_path(project['path']) }"
       echo "Now working in #{ project['name'] }"
 
-      run_hook :after
+      run_hook :after, project
       exit
     else
       echo "Project \"#{ project_key }\" not found"
@@ -113,11 +112,13 @@ class ProjectSwitcher
   end
 
   # Runs hooks specified in ~/.projects.yml
-  def run_hook(type)
+  def run_hook(type, project)
     if type == :before
       exec config['before_switch'] unless config['before_switch'].nil?
+      exec project['before_switch'] unless project['before_switch'].nil?
     elsif type == :after
       exec config['after_switch'] unless config['after_switch'].nil?
+      exec project['after_switch'] unless project['after_switch'].nil?
     end
   end
 


### PR DESCRIPTION
This PR allows you to set `before_switch` and `after_switch` hooks on a per-project basis.

Syntax is as follows:

``` yml
projects:
  home:
    # ...
    before_switch: 'clear' # (optional) Same as before_switch in config, but configurable per project. Runs after global before_switch.
    after_switch: 'pwd' # (optional) Same as after_switch in config, but configurable per project. Runs after global after_switch.
```
